### PR TITLE
지훈 BOJ 19539. 사과나무

### DIFF
--- a/boj/jihoon/0414-19539-사과나무.java
+++ b/boj/jihoon/0414-19539-사과나무.java
@@ -1,0 +1,28 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static int[] h;
+    
+    public static void main(String[] args) throws Exception{
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(in.readLine());
+        h = new int[N];
+        StringTokenizer st = new StringTokenizer(in.readLine());
+        long sum = 0;
+        long cnt2 = 0;
+        for (int i = 0; i < N; i++) {
+            h[i] = Integer.parseInt(st.nextToken());
+            sum += h[i];
+            cnt2 += h[i] / 2;
+        }
+        boolean possible = true;
+        if (sum % 3 == 0) {
+            long cnt3 = sum / 3;
+            if (cnt3 > cnt2) possible = false;
+        } else possible = false;
+
+        System.out.println(possible? "YES" : "NO");
+    }
+}


### PR DESCRIPTION
- 우선 높이의 합이 3으로 나누어져야 한다
- 높이 합을 3으로 나눈 몫은 물을 부을 수 있는 총 횟수를 의미한다.
- 1은 2를 커버할 수 있기 때문에 2의 적용 가능 횟수가 관건
- 높이를 2로 나눈 몫을 모두 더한 값이 물을 부을 수 있는 총 횟수보다 작으면 남아 있는 높이를 1로 커버할 수 없게 된다.